### PR TITLE
Review code for learning

### DIFF
--- a/myocode/main_myo_run.py
+++ b/myocode/main_myo_run.py
@@ -100,7 +100,7 @@ async def amain(args):
         elif args.view == "feat":
             await run_feat(addr=args.addr, mode=args.mode,
                            srate=200, win_ms=args.win, step_ms=args.step,
-                           use_fft=(not args.no-fft), fftlen=args.fftlen)
+                           use_fft=(not args.no_fft), fftlen=args.fftlen)
         elif args.view == "level":
             await run_level(addr=args.addr, mode=args.mode,
                             alpha=args.smooth_alpha, scales_str=args.scales, _print_hz_ignored=args.print_hz)


### PR DESCRIPTION
Fixes a typo in `myocode/main_myo_run.py` to prevent the `feat` view from crashing.

The argument `args.no-fft` was misspelled as `args.no-fft` instead of `args.no_fft`, leading to incorrect parsing and runtime errors when the `feat` view was used. This change corrects the argument name.

---
<a href="https://cursor.com/background-agent?bcId=bc-d8543c27-bb4f-420f-a6aa-857659058c1f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d8543c27-bb4f-420f-a6aa-857659058c1f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

